### PR TITLE
Add logic to continue on bad HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
     - 1.7.5
-    - 1.8.1
+    - 1.8.3
     - tip
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Package go-download
 ===================
-![Project status](https://img.shields.io/badge/version-2.0.0-green.svg)
+![Project status](https://img.shields.io/badge/version-2.1.0-green.svg)
 [![Build Status](https://travis-ci.org/joeybloggs/go-download.svg?branch=master)](https://travis-ci.org/joeybloggs/go-download)
 [![Coverage Status](https://coveralls.io/repos/github/joeybloggs/go-download/badge.svg?branch=master)](https://coveralls.io/github/joeybloggs/go-download?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/joeybloggs/go-download)](https://goreportcard.com/report/github.com/joeybloggs/go-download)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It Features:
 ```shell
 go get -u github.com/joeybloggs/go-download
 ```
+or if your looking for the standalone client
+```shell
+go get -u github.com/joeybloggs/go-download/cmd/goget
+```
 
 ## Examples
 

--- a/cmd/goget/main.go
+++ b/cmd/goget/main.go
@@ -5,11 +5,15 @@ import (
 	"io"
 	"log"
 
+	"os"
+
 	download "github.com/joeybloggs/go-download"
 	"github.com/vbauerster/mpb"
 )
 
 func main() {
+
+	url := os.Args[len(os.Args)-1]
 
 	progress := mpb.New().SetWidth(80)
 	defer progress.Stop()
@@ -25,11 +29,28 @@ func main() {
 		},
 	}
 
-	f, err := download.Open("https://storage.googleapis.com/golang/go1.8.1.src.tar.gz", options)
+	f, err := download.Open(url, options)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer f.Close()
 
-	// f implements io.Reader, write file somewhere or do some other sort of work with it
+	info, err := f.Stat()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var output *os.File
+	name := info.Name()
+	output, err = os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer output.Close()
+
+	if _, err = io.Copy(output, f); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Success. %s saved.", name)
 }

--- a/download.go
+++ b/download.go
@@ -116,7 +116,7 @@ func OpenContext(ctx context.Context, url string, options *Options) (*File, erro
 		// not all services support HEAD requests
 		// so if this fails just move along to the
 		// GET portion, with a warning
-		log.Printf("notice: unexpected HEAD response code '%d', proceeding with download.", resp.StatusCode)
+		log.Printf("notice: unexpected HEAD response code '%d', proceeding with download.\n", resp.StatusCode)
 		err = f.download(ctx)
 	} else {
 		f.size = resp.ContentLength

--- a/download_test.go
+++ b/download_test.go
@@ -85,6 +85,18 @@ func TestBadOptions(t *testing.T) {
 
 		w.WriteHeader(http.StatusNotFound)
 	})
+	mux.HandleFunc("/testdata/bad-head-good-get", func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		f, _ := os.Open(data)
+		defer f.Close()
+
+		io.Copy(w, f)
+	})
 	mux.HandleFunc("/testdata/bad-content-length", func(w http.ResponseWriter, r *http.Request) {
 
 		fi, _ := os.Stat(data)
@@ -179,6 +191,13 @@ func TestBadOptions(t *testing.T) {
 	}
 
 	f, err := Open(url, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	url = server.URL + "/testdata/bad-head-good-get"
+	f, err = Open(url, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Some services won't support `HEAD` requests so if `HEAD` request fails, a notice message is logged but the program continues to try and download.

closes #5